### PR TITLE
Use the new prop-types package

### DIFF
--- a/ToggleDisplay.jsx
+++ b/ToggleDisplay.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 ToggleDisplay.propTypes = {
-	tag: React.PropTypes.string,
-	hide: React.PropTypes.bool,
-	show: React.PropTypes.bool,
-	if: React.PropTypes.bool
+	tag: PropTypes.string,
+	hide: PropTypes.bool,
+	show: PropTypes.bool,
+	if: PropTypes.bool
 };
 
 ToggleDisplay.defaultProps = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-toggle-display",
-  "version": "2.1.1",
+  "version": "2.2.1",
   "description": "Hide/show a component's children",
   "repository": {
     "type": "git",
@@ -32,8 +32,9 @@
     "babel-preset-react": "6.1.18",
     "babel-preset-stage-0": "6.1.18",
     "cheerio": "0.19.0",
-    "react": "^15.3.0",
-    "react-dom": "^15.3.0",
+    "prop-types": "^15.5.8",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
     "tape": "4.2.2"
   }
 }


### PR DESCRIPTION
After upgrading react to 15.5, I started getting warnings that I should use the new prop-types package for defining proptypes.

I updated the relevant code in your package.